### PR TITLE
Fix cargo fmt violations and modernize CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,36 @@
 on:
   push:
-    tags:        
-      - '*'           # Push events to every tag not containing /
+    tags:
+      - '*'
   workflow_dispatch:
 
 name: Publish
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,16 +15,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Setup Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        override: true
         components: rustfmt, clippy
 
     - name: Cache cargo dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry

--- a/src/protocol/https.rs
+++ b/src/protocol/https.rs
@@ -28,9 +28,7 @@ where
 
     if crate::is_private_address(&host) {
         warn!("Blocked CONNECT to private address: {}", target);
-        writer
-            .write_all(constants::FORBIDDEN_RESPONSE)
-            .await?;
+        writer.write_all(constants::FORBIDDEN_RESPONSE).await?;
         writer.flush().await?;
         return Ok(());
     }
@@ -40,9 +38,7 @@ where
         Ok(addrs) => addrs,
         Err(e) => {
             warn!("Blocked CONNECT (DNS rebinding): {} - {}", target, e);
-            writer
-                .write_all(constants::FORBIDDEN_RESPONSE)
-                .await?;
+            writer.write_all(constants::FORBIDDEN_RESPONSE).await?;
             writer.flush().await?;
             return Ok(());
         }


### PR DESCRIPTION
## Summary

- Run `cargo fmt` across the codebase to fix all formatting violations
- Replace deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable` in test workflow
- Upgrade `actions/cache` from v3 to v4
- Add a test gate (fmt + clippy + tests) to the publish workflow so `cargo publish` only runs after CI passes

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] All 62 tests pass
- [ ] CI runs green on this PR

Closes #8, closes #9