### PR TITLE
Add comprehensive integration tests for proxy forwarding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ http = "1.3.1"
 anyhow = "1.0.99"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[features]
+# Internal feature for integration tests: allows bypassing SSRF checks
+# so tests can use localhost upstreams. Never enable in production.
+_test-support = []

--- a/src/protocol/http.rs
+++ b/src/protocol/http.rs
@@ -100,9 +100,7 @@ where
                 e,
                 e.source()
             );
-            writer
-                .write_all(constants::BAD_GATEWAY_RESPONSE)
-                .await?;
+            writer.write_all(constants::BAD_GATEWAY_RESPONSE).await?;
             writer.flush().await?;
             return Ok(());
         }
@@ -114,9 +112,7 @@ where
         }
         Err(e) => {
             error!("Failed to forward response: {}", e);
-            writer
-                .write_all(constants::BAD_GATEWAY_RESPONSE)
-                .await?;
+            writer.write_all(constants::BAD_GATEWAY_RESPONSE).await?;
             writer.flush().await?;
             return Ok(());
         }

--- a/src/protocol/https.rs
+++ b/src/protocol/https.rs
@@ -51,9 +51,7 @@ where
         Err(e) => {
             let error_message = format!("Failed to connect to {}: {}", target, e);
             warn!("{}", error_message);
-            writer
-                .write_all(constants::BAD_GATEWAY_RESPONSE)
-                .await?;
+            writer.write_all(constants::BAD_GATEWAY_RESPONSE).await?;
             writer.flush().await?;
             // Return Ok — the error is already logged and a 502 sent to the client.
             // Returning Err here would cause the caller to log the same error again.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,80 @@
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Spawn a proxy handler that mirrors `main.rs::handle_connection`.
+/// Accepts connections in a loop until the listener is dropped.
+pub async fn start_proxy() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let (reader, writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+                let mut writer = BufWriter::new(writer);
+
+                let (method, url_string) = match rhoxy::extract_request_parts(&mut reader).await {
+                    Ok(parts) => parts,
+                    Err(_) => {
+                        let _ = writer
+                            .write_all(rhoxy::constants::BAD_REQUEST_RESPONSE)
+                            .await;
+                        let _ = writer.flush().await;
+                        return;
+                    }
+                };
+
+                if rhoxy::is_health_check(&url_string) {
+                    let _ = rhoxy::handle_health_check(&mut writer).await;
+                    return;
+                }
+
+                let protocol = rhoxy::protocol::Protocol::from_method(&method);
+                let _ = protocol
+                    .handle_request(&mut writer, &mut reader, method, url_string)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Spawn a simple upstream HTTP server that accepts one connection,
+/// reads whatever is sent, and responds with the given canned response.
+#[allow(dead_code)]
+pub async fn start_upstream(response: &'static [u8]) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 8192];
+        let _ = stream.read(&mut buf).await;
+        stream.write_all(response).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    addr
+}
+
+/// Send raw bytes to a TCP address, shut down the write half, and read
+/// the full response.
+pub async fn send_raw(addr: std::net::SocketAddr, request: &[u8]) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request).await.unwrap();
+    stream.shutdown().await.unwrap();
+
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
+        .await
+        .expect("Timed out reading response")
+        .expect("Failed to read response");
+
+    String::from_utf8_lossy(&response).into_owned()
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Semaphore;
 
 /// Spawn a proxy using the same `handle_connection` as production.
 /// Accepts connections in a loop until the listener is dropped.
+#[allow(dead_code)]
 pub async fn start_proxy() -> std::net::SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -19,6 +22,95 @@ pub async fn start_proxy() -> std::net::SocketAddr {
                 let mut writer = BufWriter::new(writer);
 
                 let _ = rhoxy::handle_connection(&mut writer, &mut reader, None).await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Like `start_proxy` but wraps each connection in a timeout.
+/// Mirrors `main.rs` timeout behavior.
+#[allow(dead_code)]
+pub async fn start_proxy_with_timeout(timeout: Duration) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let (reader, writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+                let mut writer = BufWriter::new(writer);
+
+                let _ = tokio::time::timeout(
+                    timeout,
+                    rhoxy::handle_connection(&mut writer, &mut reader, None),
+                )
+                .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Like `start_proxy` but limits concurrent connections via a semaphore.
+/// Mirrors `main.rs` connection limiting behavior.
+#[allow(dead_code)]
+pub async fn start_proxy_with_limit(max_connections: usize) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let semaphore = Arc::new(Semaphore::new(max_connections));
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+
+            let permit = match semaphore.clone().try_acquire_owned() {
+                Ok(permit) => permit,
+                Err(_) => {
+                    drop(stream);
+                    continue;
+                }
+            };
+
+            tokio::spawn(async move {
+                let _permit = permit;
+                let (reader, writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+                let mut writer = BufWriter::new(writer);
+
+                let _ = rhoxy::handle_connection(&mut writer, &mut reader, None).await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Like `start_upstream` but accepts connections in a loop (not just one).
+/// Used by concurrent-requests tests.
+#[allow(dead_code)]
+pub async fn start_looping_upstream(response: &'static [u8]) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let mut buf = vec![0u8; 8192];
+                let _ = stream.read(&mut buf).await;
+                let _ = stream.write_all(response).await;
+                let _ = stream.shutdown().await;
             });
         }
     });

--- a/tests/malformed_request.rs
+++ b/tests/malformed_request.rs
@@ -1,75 +1,25 @@
-use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpStream;
-
-/// Start the proxy server on a random port and return the address.
-async fn start_proxy() -> std::net::SocketAddr {
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        // Accept one connection and run it through the same path as main.rs
-        let (stream, _) = listener.accept().await.unwrap();
-        let (reader, writer) = stream.into_split();
-        let mut reader = tokio::io::BufReader::new(reader);
-        let mut writer = tokio::io::BufWriter::new(writer);
-
-        match rhoxy::extract_request_parts(&mut reader).await {
-            Ok(_) => panic!("Expected malformed request to fail parsing"),
-            Err(_) => {
-                let _ = writer
-                    .write_all(rhoxy::constants::BAD_REQUEST_RESPONSE)
-                    .await;
-                let _ = writer.flush().await;
-            }
-        }
-    });
-
-    addr
-}
+mod common;
 
 #[tokio::test]
 async fn test_malformed_request_returns_400() {
-    let addr = start_proxy().await;
+    let proxy = common::start_proxy().await;
+    let response = common::send_raw(proxy, b"NOT-A-VALID-REQUEST\r\n").await;
 
-    let mut stream = TcpStream::connect(addr).await.unwrap();
-    // Send garbage that isn't a valid HTTP request line
-    stream.write_all(b"NOT-A-VALID-REQUEST\r\n").await.unwrap();
-    stream.flush().await.unwrap();
-
-    let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(2), stream.read_to_end(&mut response))
-        .await
-        .expect("Timed out waiting for response")
-        .expect("Failed to read response");
-
-    let response_str = String::from_utf8_lossy(&response);
     assert!(
-        response_str.contains("400 Bad Request"),
+        response.contains("400 Bad Request"),
         "Expected 400 Bad Request, got: {}",
-        response_str
+        response
     );
 }
 
 #[tokio::test]
 async fn test_empty_request_returns_400() {
-    let addr = start_proxy().await;
+    let proxy = common::start_proxy().await;
+    let response = common::send_raw(proxy, b"\r\n").await;
 
-    let mut stream = TcpStream::connect(addr).await.unwrap();
-    // Send just a bare CRLF — empty request line
-    stream.write_all(b"\r\n").await.unwrap();
-    stream.flush().await.unwrap();
-
-    let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(2), stream.read_to_end(&mut response))
-        .await
-        .expect("Timed out waiting for response")
-        .expect("Failed to read response");
-
-    let response_str = String::from_utf8_lossy(&response);
     assert!(
-        response_str.contains("400 Bad Request"),
+        response.contains("400 Bad Request"),
         "Expected 400 Bad Request, got: {}",
-        response_str
+        response
     );
 }

--- a/tests/proxy_forwarding.rs
+++ b/tests/proxy_forwarding.rs
@@ -1,0 +1,292 @@
+//! Integration tests for HTTP forwarding through the proxy.
+//!
+//! These tests require the `_test-support` feature because they use localhost
+//! upstreams. The SSRF bypass is enabled so the proxy can forward to local
+//! addresses. Run with:
+//!
+//!     cargo test --features _test-support --test proxy_forwarding
+#![cfg(feature = "_test-support")]
+
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Spawn a proxy handler that mimics main.rs handle_connection.
+async fn start_proxy() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let (reader, writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+                let mut writer = BufWriter::new(writer);
+
+                let (method, url_string) = match rhoxy::extract_request_parts(&mut reader).await {
+                    Ok(parts) => parts,
+                    Err(_) => {
+                        let _ = writer
+                            .write_all(rhoxy::constants::BAD_REQUEST_RESPONSE)
+                            .await;
+                        let _ = writer.flush().await;
+                        return;
+                    }
+                };
+
+                if rhoxy::is_health_check(&url_string) {
+                    let _ = rhoxy::handle_health_check(&mut writer).await;
+                    return;
+                }
+
+                let protocol = rhoxy::protocol::Protocol::from_method(&method);
+                let _ = protocol
+                    .handle_request(&mut writer, &mut reader, method, url_string)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Spawn a simple upstream HTTP server that reads one request and sends a
+/// canned response.
+async fn start_upstream(response: &'static [u8]) -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 8192];
+        let _ = stream.read(&mut buf).await;
+        stream.write_all(response).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    addr
+}
+
+/// Send raw bytes to a TCP address and read the full response.
+async fn send_raw(addr: std::net::SocketAddr, request: &[u8]) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request).await.unwrap();
+    stream.shutdown().await.unwrap();
+
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
+        .await
+        .expect("Timed out reading response")
+        .expect("Failed to read response");
+
+    String::from_utf8_lossy(&response).into_owned()
+}
+
+fn enable_ssrf_bypass() {
+    rhoxy::test_support::set_ssrf_bypass(true);
+}
+
+// ---------------------------------------------------------------------------
+// HTTP forwarding
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_http_get_forwarding() {
+    enable_ssrf_bypass();
+
+    let upstream = start_upstream(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello").await;
+    let proxy = start_proxy().await;
+
+    let request = format!(
+        "GET http://{}/path HTTP/1.1\r\nHost: {}\r\n\r\n",
+        upstream, upstream
+    );
+    let response = send_raw(proxy, request.as_bytes()).await;
+
+    assert!(response.contains("200"), "Expected 200, got: {}", response);
+    assert!(
+        response.contains("hello"),
+        "Expected body 'hello', got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_http_post_with_body() {
+    enable_ssrf_bypass();
+
+    let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (stream, _) = upstream_listener.accept().await.unwrap();
+        let (reader, writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+        let mut writer = BufWriter::new(writer);
+
+        let mut content_length = 0usize;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            reader.read_line(&mut line).await.unwrap();
+            if line.trim().is_empty() {
+                break;
+            }
+            if let Some(val) = line.strip_prefix("content-length: ") {
+                content_length = val.trim().parse().unwrap_or(0);
+            }
+        }
+
+        let mut body = vec![0u8; content_length];
+        if content_length > 0 {
+            reader.read_exact(&mut body).await.unwrap();
+        }
+
+        let resp_body = format!("received {} bytes", body.len());
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            resp_body.len(),
+            resp_body
+        );
+        writer.write_all(resp.as_bytes()).await.unwrap();
+        writer.flush().await.unwrap();
+    });
+
+    let proxy = start_proxy().await;
+    let body = "test body payload";
+    let request = format!(
+        "POST http://{}/submit HTTP/1.1\r\nHost: {}\r\nContent-Length: {}\r\n\r\n{}",
+        upstream_addr,
+        upstream_addr,
+        body.len(),
+        body
+    );
+    let response = send_raw(proxy, request.as_bytes()).await;
+
+    assert!(response.contains("200"), "Expected 200, got: {}", response);
+    assert!(
+        response.contains("received 17 bytes"),
+        "Expected upstream to receive body, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_http_response_headers_forwarded() {
+    enable_ssrf_bypass();
+
+    let upstream =
+        start_upstream(b"HTTP/1.1 200 OK\r\nX-Custom: test-value\r\nContent-Length: 2\r\n\r\nOK")
+            .await;
+    let proxy = start_proxy().await;
+
+    let request = format!(
+        "GET http://{}/path HTTP/1.1\r\nHost: {}\r\n\r\n",
+        upstream, upstream
+    );
+    let response = send_raw(proxy, request.as_bytes()).await;
+
+    assert!(
+        response.contains("x-custom: test-value") || response.contains("X-Custom: test-value"),
+        "Expected X-Custom header in response, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_http_hop_by_hop_headers_stripped() {
+    enable_ssrf_bypass();
+
+    let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let upstream_addr = upstream_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = upstream_listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 8192];
+        let n = stream.read(&mut buf).await.unwrap();
+        let received = String::from_utf8_lossy(&buf[..n]);
+
+        let has_proxy_auth = received
+            .lines()
+            .any(|l| l.to_lowercase().starts_with("proxy-authorization:"));
+
+        let body = if has_proxy_auth { "LEAKED" } else { "CLEAN" };
+
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream.write_all(resp.as_bytes()).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let proxy = start_proxy().await;
+    let request = format!(
+        "GET http://{}/path HTTP/1.1\r\nHost: {}\r\nProxy-Authorization: Basic secret\r\nX-Keep: yes\r\n\r\n",
+        upstream_addr, upstream_addr
+    );
+    let response = send_raw(proxy, request.as_bytes()).await;
+
+    assert!(response.contains("200"), "Expected 200, got: {}", response);
+    assert!(
+        response.contains("CLEAN"),
+        "Proxy-Authorization should be stripped before forwarding, got: {}",
+        response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Health check non-interception for absolute URLs
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_health_check_not_intercepted_for_absolute_url() {
+    enable_ssrf_bypass();
+
+    let upstream =
+        start_upstream(b"HTTP/1.1 418 I'm a Teapot\r\nContent-Length: 6\r\n\r\nteapot").await;
+    let proxy = start_proxy().await;
+
+    let request = format!(
+        "GET http://{}/health HTTP/1.1\r\nHost: {}\r\n\r\n",
+        upstream, upstream
+    );
+    let response = send_raw(proxy, request.as_bytes()).await;
+
+    assert!(
+        response.contains("418"),
+        "Absolute /health should be forwarded to upstream, got: {}",
+        response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Multiple requests through same proxy
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_proxy_handles_multiple_sequential_requests() {
+    enable_ssrf_bypass();
+
+    let proxy = start_proxy().await;
+
+    for i in 0..3 {
+        let upstream = start_upstream(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK").await;
+
+        let request = format!(
+            "GET http://{}/path/{} HTTP/1.1\r\nHost: {}\r\n\r\n",
+            upstream, i, upstream
+        );
+        let response = send_raw(proxy, request.as_bytes()).await;
+        assert!(
+            response.contains("200"),
+            "Request {} failed, got: {}",
+            i,
+            response
+        );
+    }
+}

--- a/tests/proxy_forwarding.rs
+++ b/tests/proxy_forwarding.rs
@@ -1,92 +1,26 @@
-//! Integration tests for HTTP forwarding through the proxy.
+//! Integration tests for HTTP/HTTPS forwarding through the proxy.
 //!
 //! These tests require the `_test-support` feature because they use localhost
-//! upstreams. The SSRF bypass is enabled so the proxy can forward to local
-//! addresses. Run with:
+//! upstreams. The SSRF bypass is enabled once for the entire binary.
 //!
 //!     cargo test --features _test-support --test proxy_forwarding
 #![cfg(feature = "_test-support")]
 
+mod common;
+
+use std::sync::Once;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
 use tokio::net::{TcpListener, TcpStream};
 
-/// Spawn a proxy handler that mimics main.rs handle_connection.
-async fn start_proxy() -> std::net::SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
+static INIT: Once = Once::new();
 
-    tokio::spawn(async move {
-        loop {
-            let Ok((stream, _)) = listener.accept().await else {
-                break;
-            };
-            tokio::spawn(async move {
-                let (reader, writer) = stream.into_split();
-                let mut reader = BufReader::new(reader);
-                let mut writer = BufWriter::new(writer);
-
-                let (method, url_string) = match rhoxy::extract_request_parts(&mut reader).await {
-                    Ok(parts) => parts,
-                    Err(_) => {
-                        let _ = writer
-                            .write_all(rhoxy::constants::BAD_REQUEST_RESPONSE)
-                            .await;
-                        let _ = writer.flush().await;
-                        return;
-                    }
-                };
-
-                if rhoxy::is_health_check(&url_string) {
-                    let _ = rhoxy::handle_health_check(&mut writer).await;
-                    return;
-                }
-
-                let protocol = rhoxy::protocol::Protocol::from_method(&method);
-                let _ = protocol
-                    .handle_request(&mut writer, &mut reader, method, url_string)
-                    .await;
-            });
-        }
+/// Enable SSRF bypass once for the entire test binary. Every test in this file
+/// needs it because they forward to localhost upstreams.
+fn setup() {
+    INIT.call_once(|| {
+        rhoxy::test_support::set_ssrf_bypass(true);
     });
-
-    addr
-}
-
-/// Spawn a simple upstream HTTP server that reads one request and sends a
-/// canned response.
-async fn start_upstream(response: &'static [u8]) -> std::net::SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        let (mut stream, _) = listener.accept().await.unwrap();
-        let mut buf = vec![0u8; 8192];
-        let _ = stream.read(&mut buf).await;
-        stream.write_all(response).await.unwrap();
-        stream.shutdown().await.unwrap();
-    });
-
-    addr
-}
-
-/// Send raw bytes to a TCP address and read the full response.
-async fn send_raw(addr: std::net::SocketAddr, request: &[u8]) -> String {
-    let mut stream = TcpStream::connect(addr).await.unwrap();
-    stream.write_all(request).await.unwrap();
-    stream.shutdown().await.unwrap();
-
-    let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
-        .await
-        .expect("Timed out reading response")
-        .expect("Failed to read response");
-
-    String::from_utf8_lossy(&response).into_owned()
-}
-
-fn enable_ssrf_bypass() {
-    rhoxy::test_support::set_ssrf_bypass(true);
 }
 
 // ---------------------------------------------------------------------------
@@ -95,16 +29,17 @@ fn enable_ssrf_bypass() {
 
 #[tokio::test]
 async fn test_http_get_forwarding() {
-    enable_ssrf_bypass();
+    setup();
 
-    let upstream = start_upstream(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello").await;
-    let proxy = start_proxy().await;
+    let upstream =
+        common::start_upstream(b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello").await;
+    let proxy = common::start_proxy().await;
 
     let request = format!(
         "GET http://{}/path HTTP/1.1\r\nHost: {}\r\n\r\n",
         upstream, upstream
     );
-    let response = send_raw(proxy, request.as_bytes()).await;
+    let response = common::send_raw(proxy, request.as_bytes()).await;
 
     assert!(response.contains("200"), "Expected 200, got: {}", response);
     assert!(
@@ -116,7 +51,7 @@ async fn test_http_get_forwarding() {
 
 #[tokio::test]
 async fn test_http_post_with_body() {
-    enable_ssrf_bypass();
+    setup();
 
     let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let upstream_addr = upstream_listener.local_addr().unwrap();
@@ -155,7 +90,7 @@ async fn test_http_post_with_body() {
         writer.flush().await.unwrap();
     });
 
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
     let body = "test body payload";
     let request = format!(
         "POST http://{}/submit HTTP/1.1\r\nHost: {}\r\nContent-Length: {}\r\n\r\n{}",
@@ -164,7 +99,7 @@ async fn test_http_post_with_body() {
         body.len(),
         body
     );
-    let response = send_raw(proxy, request.as_bytes()).await;
+    let response = common::send_raw(proxy, request.as_bytes()).await;
 
     assert!(response.contains("200"), "Expected 200, got: {}", response);
     assert!(
@@ -176,18 +111,19 @@ async fn test_http_post_with_body() {
 
 #[tokio::test]
 async fn test_http_response_headers_forwarded() {
-    enable_ssrf_bypass();
+    setup();
 
-    let upstream =
-        start_upstream(b"HTTP/1.1 200 OK\r\nX-Custom: test-value\r\nContent-Length: 2\r\n\r\nOK")
-            .await;
-    let proxy = start_proxy().await;
+    let upstream = common::start_upstream(
+        b"HTTP/1.1 200 OK\r\nX-Custom: test-value\r\nContent-Length: 2\r\n\r\nOK",
+    )
+    .await;
+    let proxy = common::start_proxy().await;
 
     let request = format!(
         "GET http://{}/path HTTP/1.1\r\nHost: {}\r\n\r\n",
         upstream, upstream
     );
-    let response = send_raw(proxy, request.as_bytes()).await;
+    let response = common::send_raw(proxy, request.as_bytes()).await;
 
     assert!(
         response.contains("x-custom: test-value") || response.contains("X-Custom: test-value"),
@@ -197,8 +133,8 @@ async fn test_http_response_headers_forwarded() {
 }
 
 #[tokio::test]
-async fn test_http_hop_by_hop_headers_stripped() {
-    enable_ssrf_bypass();
+async fn test_http_hop_by_hop_headers_stripped_and_others_forwarded() {
+    setup();
 
     let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let upstream_addr = upstream_listener.local_addr().unwrap();
@@ -212,8 +148,15 @@ async fn test_http_hop_by_hop_headers_stripped() {
         let has_proxy_auth = received
             .lines()
             .any(|l| l.to_lowercase().starts_with("proxy-authorization:"));
+        let has_x_keep = received
+            .lines()
+            .any(|l| l.to_lowercase().starts_with("x-keep:"));
 
-        let body = if has_proxy_auth { "LEAKED" } else { "CLEAN" };
+        let body = match (has_proxy_auth, has_x_keep) {
+            (false, true) => "STRIPPED_AND_KEPT",
+            (true, _) => "LEAKED",
+            (false, false) => "OVER_STRIPPED",
+        };
 
         let resp = format!(
             "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
@@ -224,17 +167,17 @@ async fn test_http_hop_by_hop_headers_stripped() {
         stream.shutdown().await.unwrap();
     });
 
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
     let request = format!(
         "GET http://{}/path HTTP/1.1\r\nHost: {}\r\nProxy-Authorization: Basic secret\r\nX-Keep: yes\r\n\r\n",
         upstream_addr, upstream_addr
     );
-    let response = send_raw(proxy, request.as_bytes()).await;
+    let response = common::send_raw(proxy, request.as_bytes()).await;
 
     assert!(response.contains("200"), "Expected 200, got: {}", response);
     assert!(
-        response.contains("CLEAN"),
-        "Proxy-Authorization should be stripped before forwarding, got: {}",
+        response.contains("STRIPPED_AND_KEPT"),
+        "Expected hop-by-hop stripped and non-hop-by-hop kept, got: {}",
         response
     );
 }
@@ -245,17 +188,18 @@ async fn test_http_hop_by_hop_headers_stripped() {
 
 #[tokio::test]
 async fn test_health_check_not_intercepted_for_absolute_url() {
-    enable_ssrf_bypass();
+    setup();
 
     let upstream =
-        start_upstream(b"HTTP/1.1 418 I'm a Teapot\r\nContent-Length: 6\r\n\r\nteapot").await;
-    let proxy = start_proxy().await;
+        common::start_upstream(b"HTTP/1.1 418 I'm a Teapot\r\nContent-Length: 6\r\n\r\nteapot")
+            .await;
+    let proxy = common::start_proxy().await;
 
     let request = format!(
         "GET http://{}/health HTTP/1.1\r\nHost: {}\r\n\r\n",
         upstream, upstream
     );
-    let response = send_raw(proxy, request.as_bytes()).await;
+    let response = common::send_raw(proxy, request.as_bytes()).await;
 
     assert!(
         response.contains("418"),
@@ -265,23 +209,148 @@ async fn test_health_check_not_intercepted_for_absolute_url() {
 }
 
 // ---------------------------------------------------------------------------
+// 502 Bad Gateway — deterministic (closed port)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_http_502_on_closed_port() {
+    setup();
+
+    // Bind and immediately drop to get a port guaranteed not listening.
+    let dead = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = dead.local_addr().unwrap();
+    drop(dead);
+
+    let proxy = common::start_proxy().await;
+    let request = format!(
+        "GET http://{}/path HTTP/1.1\r\nHost: {}\r\n\r\n",
+        dead_addr, dead_addr
+    );
+    let response = common::send_raw(proxy, request.as_bytes()).await;
+
+    assert!(
+        response.contains("502 Bad Gateway"),
+        "Expected 502 for closed port, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_connect_502_on_closed_port() {
+    setup();
+
+    let dead = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let dead_addr = dead.local_addr().unwrap();
+    drop(dead);
+
+    let proxy = common::start_proxy().await;
+    let request = format!(
+        "CONNECT {} HTTP/1.1\r\nHost: {}\r\n\r\n",
+        dead_addr, dead_addr
+    );
+    let response = common::send_raw(proxy, request.as_bytes()).await;
+
+    assert!(
+        response.contains("502 Bad Gateway"),
+        "Expected 502 for CONNECT to closed port, got: {}",
+        response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CONNECT tunnel — bidirectional data
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_connect_tunnel_bidirectional() {
+    setup();
+
+    // Start a TCP echo server: reads data, sends it back prefixed with "echo:".
+    let echo_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo_addr = echo_listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = echo_listener.accept().await.unwrap();
+        let mut buf = vec![0u8; 1024];
+        let n = stream.read(&mut buf).await.unwrap();
+        let mut response = b"echo:".to_vec();
+        response.extend_from_slice(&buf[..n]);
+        stream.write_all(&response).await.unwrap();
+        stream.shutdown().await.unwrap();
+    });
+
+    let proxy = common::start_proxy().await;
+    let mut stream = TcpStream::connect(proxy).await.unwrap();
+
+    // Phase 1: Send CONNECT request
+    let connect_req = format!(
+        "CONNECT {} HTTP/1.1\r\nHost: {}\r\n\r\n",
+        echo_addr, echo_addr
+    );
+    stream.write_all(connect_req.as_bytes()).await.unwrap();
+
+    // Phase 2: Read "200 Connection Established\r\n\r\n"
+    let mut buf = vec![0u8; 256];
+    let mut total = 0;
+    loop {
+        let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf[total..]))
+            .await
+            .expect("Timed out waiting for CONNECT response")
+            .expect("Failed to read CONNECT response");
+        assert!(n > 0, "Connection closed before tunnel established");
+        total += n;
+        if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    let establishment = String::from_utf8_lossy(&buf[..total]);
+    assert!(
+        establishment.contains("200 Connection Established"),
+        "Expected tunnel established, got: {}",
+        establishment
+    );
+
+    // Phase 3: Send data through the tunnel
+    stream.write_all(b"hello tunnel").await.unwrap();
+    stream.shutdown().await.unwrap();
+
+    // Phase 4: Read echo response through the tunnel
+    let mut tunnel_response = Vec::new();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        stream.read_to_end(&mut tunnel_response),
+    )
+    .await
+    .expect("Timed out reading tunnel data")
+    .expect("Failed to read tunnel data");
+
+    let tunnel_str = String::from_utf8_lossy(&tunnel_response);
+    assert!(
+        tunnel_str.contains("echo:hello tunnel"),
+        "Expected echo response through tunnel, got: {}",
+        tunnel_str
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Multiple requests through same proxy
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn test_proxy_handles_multiple_sequential_requests() {
-    enable_ssrf_bypass();
+    setup();
 
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
 
     for i in 0..3 {
-        let upstream = start_upstream(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK").await;
+        let upstream =
+            common::start_upstream(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK").await;
 
         let request = format!(
             "GET http://{}/path/{} HTTP/1.1\r\nHost: {}\r\n\r\n",
             upstream, i, upstream
         );
-        let response = send_raw(proxy, request.as_bytes()).await;
+        let response = common::send_raw(proxy, request.as_bytes()).await;
         assert!(
             response.contains("200"),
             "Request {} failed, got: {}",

--- a/tests/proxy_forwarding.rs
+++ b/tests/proxy_forwarding.rs
@@ -24,6 +24,19 @@ fn setup() {
 }
 
 // ---------------------------------------------------------------------------
+// SSRF bypass verification
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_ssrf_bypass_active() {
+    setup();
+    assert!(
+        !rhoxy::is_private_address("127.0.0.1"),
+        "SSRF bypass should be active in this test binary"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // HTTP forwarding
 // ---------------------------------------------------------------------------
 
@@ -102,8 +115,9 @@ async fn test_http_post_with_body() {
     let response = common::send_raw(proxy, request.as_bytes()).await;
 
     assert!(response.contains("200"), "Expected 200, got: {}", response);
+    let expected = format!("received {} bytes", body.len());
     assert!(
-        response.contains("received 17 bytes"),
+        response.contains(&expected),
         "Expected upstream to receive body, got: {}",
         response
     );

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -17,9 +17,25 @@ async fn test_health_check_returns_200() {
         response
     );
     assert!(
-        response.contains("OK"),
-        "Expected 'OK' body, got: {}",
+        response.ends_with("OK"),
+        "Expected 'OK' body at end of response, got: {}",
         response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SSRF bypass sanity check
+// ---------------------------------------------------------------------------
+
+/// Verify SSRF protection is active in this test binary. If this fails, the
+/// `_test-support` feature flag or a stray `set_ssrf_bypass(true)` is leaking
+/// bypass state into tests that depend on SSRF blocking.
+#[cfg(feature = "_test-support")]
+#[test]
+fn test_ssrf_bypass_not_active_in_integration_tests() {
+    assert!(
+        rhoxy::is_private_address("127.0.0.1"),
+        "SSRF protection should be active — bypass must not leak into this binary"
     );
 }
 

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -1,0 +1,211 @@
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Spawn a proxy handler that mimics main.rs handle_connection.
+/// Returns the proxy's listen address.
+async fn start_proxy() -> std::net::SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let (reader, writer) = stream.into_split();
+                let mut reader = BufReader::new(reader);
+                let mut writer = BufWriter::new(writer);
+
+                let (method, url_string) = match rhoxy::extract_request_parts(&mut reader).await {
+                    Ok(parts) => parts,
+                    Err(_) => {
+                        let _ = writer
+                            .write_all(rhoxy::constants::BAD_REQUEST_RESPONSE)
+                            .await;
+                        let _ = writer.flush().await;
+                        return;
+                    }
+                };
+
+                if rhoxy::is_health_check(&url_string) {
+                    let _ = rhoxy::handle_health_check(&mut writer).await;
+                    return;
+                }
+
+                let protocol = rhoxy::protocol::Protocol::from_method(&method);
+                let _ = protocol
+                    .handle_request(&mut writer, &mut reader, method, url_string)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Send raw bytes to a TCP address and read the full response.
+async fn send_raw(addr: std::net::SocketAddr, request: &[u8]) -> String {
+    let mut stream = TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request).await.unwrap();
+    stream.shutdown().await.unwrap();
+
+    let mut response = Vec::new();
+    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
+        .await
+        .expect("Timed out reading response")
+        .expect("Failed to read response");
+
+    String::from_utf8_lossy(&response).into_owned()
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_health_check_returns_200() {
+    let proxy = start_proxy().await;
+
+    let request = b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    let response = send_raw(proxy, request).await;
+
+    assert!(
+        response.contains("200 OK"),
+        "Expected 200 OK for health check, got: {}",
+        response
+    );
+    assert!(
+        response.contains("OK"),
+        "Expected 'OK' body, got: {}",
+        response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SSRF protection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_http_ssrf_block_private_address() {
+    let proxy = start_proxy().await;
+
+    let request = b"GET http://127.0.0.1/secret HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n";
+    let response = send_raw(proxy, request).await;
+
+    assert!(
+        response.contains("403 Forbidden"),
+        "Expected 403 for private address, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_connect_ssrf_block_private_address() {
+    let proxy = start_proxy().await;
+
+    let request = b"CONNECT 127.0.0.1:443 HTTP/1.1\r\nHost: 127.0.0.1:443\r\n\r\n";
+    let response = send_raw(proxy, request).await;
+
+    assert!(
+        response.contains("403 Forbidden"),
+        "Expected 403 for CONNECT to private address, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_http_ssrf_block_localhost() {
+    let proxy = start_proxy().await;
+
+    let request = b"GET http://localhost/secret HTTP/1.1\r\nHost: localhost\r\n\r\n";
+    let response = send_raw(proxy, request).await;
+
+    assert!(
+        response.contains("403 Forbidden"),
+        "Expected 403 for localhost, got: {}",
+        response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error handling — 502 Bad Gateway
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_http_502_on_upstream_failure() {
+    // Can't test 502 through the full proxy because the SSRF filter blocks
+    // all private addresses. Test the handler directly with a non-routable host.
+    let mut writer = Vec::new();
+    let headers_and_body = "Host: unreachable.test.invalid\r\n\r\n";
+    let mut reader = tokio::io::BufReader::new(std::io::Cursor::new(headers_and_body));
+
+    let result = rhoxy::protocol::http::handle_request(
+        &mut writer,
+        &mut reader,
+        http::Method::GET,
+        "http://unreachable.test.invalid:1/path".to_string(),
+    )
+    .await;
+
+    assert!(
+        result.is_ok(),
+        "Handler should not propagate error: {:?}",
+        result.err()
+    );
+    let response = String::from_utf8_lossy(&writer);
+    assert!(
+        response.contains("502 Bad Gateway") || response.contains("403 Forbidden"),
+        "Expected 502 or 403 for unreachable host, got: {}",
+        response
+    );
+}
+
+// ---------------------------------------------------------------------------
+// HTTPS CONNECT tunnel
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_connect_tunnel_ssrf_blocks_private() {
+    let mut writer = Vec::new();
+    let mut reader = tokio::io::BufReader::new(std::io::Cursor::new("Host: 127.0.0.1:443\r\n\r\n"));
+
+    let result = rhoxy::protocol::https::handle_request(
+        &mut writer,
+        &mut reader,
+        "127.0.0.1:443".to_string(),
+    )
+    .await;
+
+    assert!(result.is_ok());
+    let response = String::from_utf8_lossy(&writer);
+    assert!(
+        response.contains("403 Forbidden"),
+        "Expected 403 for CONNECT to localhost, got: {}",
+        response
+    );
+}
+
+#[tokio::test]
+async fn test_connect_tunnel_unreachable_host() {
+    let mut writer = Vec::new();
+    let mut reader = tokio::io::BufReader::new(std::io::Cursor::new(
+        "Host: unreachable.test.invalid:1\r\n\r\n",
+    ));
+
+    let result = rhoxy::protocol::https::handle_request(
+        &mut writer,
+        &mut reader,
+        "unreachable.test.invalid:1".to_string(),
+    )
+    .await;
+
+    assert!(result.is_ok(), "Handler should not propagate error");
+    let response = String::from_utf8_lossy(&writer);
+    assert!(
+        response.contains("502 Bad Gateway") || response.contains("403 Forbidden"),
+        "Expected 502 or 403, got: {}",
+        response
+    );
+}

--- a/tests/proxy_integration.rs
+++ b/tests/proxy_integration.rs
@@ -1,64 +1,4 @@
-use std::time::Duration;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader, BufWriter};
-use tokio::net::{TcpListener, TcpStream};
-
-/// Spawn a proxy handler that mimics main.rs handle_connection.
-/// Returns the proxy's listen address.
-async fn start_proxy() -> std::net::SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        loop {
-            let Ok((stream, _)) = listener.accept().await else {
-                break;
-            };
-            tokio::spawn(async move {
-                let (reader, writer) = stream.into_split();
-                let mut reader = BufReader::new(reader);
-                let mut writer = BufWriter::new(writer);
-
-                let (method, url_string) = match rhoxy::extract_request_parts(&mut reader).await {
-                    Ok(parts) => parts,
-                    Err(_) => {
-                        let _ = writer
-                            .write_all(rhoxy::constants::BAD_REQUEST_RESPONSE)
-                            .await;
-                        let _ = writer.flush().await;
-                        return;
-                    }
-                };
-
-                if rhoxy::is_health_check(&url_string) {
-                    let _ = rhoxy::handle_health_check(&mut writer).await;
-                    return;
-                }
-
-                let protocol = rhoxy::protocol::Protocol::from_method(&method);
-                let _ = protocol
-                    .handle_request(&mut writer, &mut reader, method, url_string)
-                    .await;
-            });
-        }
-    });
-
-    addr
-}
-
-/// Send raw bytes to a TCP address and read the full response.
-async fn send_raw(addr: std::net::SocketAddr, request: &[u8]) -> String {
-    let mut stream = TcpStream::connect(addr).await.unwrap();
-    stream.write_all(request).await.unwrap();
-    stream.shutdown().await.unwrap();
-
-    let mut response = Vec::new();
-    tokio::time::timeout(Duration::from_secs(5), stream.read_to_end(&mut response))
-        .await
-        .expect("Timed out reading response")
-        .expect("Failed to read response");
-
-    String::from_utf8_lossy(&response).into_owned()
-}
+mod common;
 
 // ---------------------------------------------------------------------------
 // Health check
@@ -66,10 +6,10 @@ async fn send_raw(addr: std::net::SocketAddr, request: &[u8]) -> String {
 
 #[tokio::test]
 async fn test_health_check_returns_200() {
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
 
-    let request = b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    let response = send_raw(proxy, request).await;
+    let response =
+        common::send_raw(proxy, b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
 
     assert!(
         response.contains("200 OK"),
@@ -84,15 +24,18 @@ async fn test_health_check_returns_200() {
 }
 
 // ---------------------------------------------------------------------------
-// SSRF protection
+// SSRF protection — full proxy
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 async fn test_http_ssrf_block_private_address() {
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
 
-    let request = b"GET http://127.0.0.1/secret HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n";
-    let response = send_raw(proxy, request).await;
+    let response = common::send_raw(
+        proxy,
+        b"GET http://127.0.0.1/secret HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+    )
+    .await;
 
     assert!(
         response.contains("403 Forbidden"),
@@ -103,10 +46,13 @@ async fn test_http_ssrf_block_private_address() {
 
 #[tokio::test]
 async fn test_connect_ssrf_block_private_address() {
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
 
-    let request = b"CONNECT 127.0.0.1:443 HTTP/1.1\r\nHost: 127.0.0.1:443\r\n\r\n";
-    let response = send_raw(proxy, request).await;
+    let response = common::send_raw(
+        proxy,
+        b"CONNECT 127.0.0.1:443 HTTP/1.1\r\nHost: 127.0.0.1:443\r\n\r\n",
+    )
+    .await;
 
     assert!(
         response.contains("403 Forbidden"),
@@ -117,10 +63,13 @@ async fn test_connect_ssrf_block_private_address() {
 
 #[tokio::test]
 async fn test_http_ssrf_block_localhost() {
-    let proxy = start_proxy().await;
+    let proxy = common::start_proxy().await;
 
-    let request = b"GET http://localhost/secret HTTP/1.1\r\nHost: localhost\r\n\r\n";
-    let response = send_raw(proxy, request).await;
+    let response = common::send_raw(
+        proxy,
+        b"GET http://localhost/secret HTTP/1.1\r\nHost: localhost\r\n\r\n",
+    )
+    .await;
 
     assert!(
         response.contains("403 Forbidden"),
@@ -130,82 +79,23 @@ async fn test_http_ssrf_block_localhost() {
 }
 
 // ---------------------------------------------------------------------------
-// Error handling — 502 Bad Gateway
+// SSRF protection — handler-level
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_http_502_on_upstream_failure() {
-    // Can't test 502 through the full proxy because the SSRF filter blocks
-    // all private addresses. Test the handler directly with a non-routable host.
-    let mut writer = Vec::new();
-    let headers_and_body = "Host: unreachable.test.invalid\r\n\r\n";
-    let mut reader = tokio::io::BufReader::new(std::io::Cursor::new(headers_and_body));
-
-    let result = rhoxy::protocol::http::handle_request(
-        &mut writer,
-        &mut reader,
-        http::Method::GET,
-        "http://unreachable.test.invalid:1/path".to_string(),
-    )
-    .await;
-
-    assert!(
-        result.is_ok(),
-        "Handler should not propagate error: {:?}",
-        result.err()
-    );
-    let response = String::from_utf8_lossy(&writer);
-    assert!(
-        response.contains("502 Bad Gateway") || response.contains("403 Forbidden"),
-        "Expected 502 or 403 for unreachable host, got: {}",
-        response
-    );
-}
-
-// ---------------------------------------------------------------------------
-// HTTPS CONNECT tunnel
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn test_connect_tunnel_ssrf_blocks_private() {
+async fn test_connect_handler_ssrf_blocks_private() {
     let mut writer = Vec::new();
     let mut reader = tokio::io::BufReader::new(std::io::Cursor::new("Host: 127.0.0.1:443\r\n\r\n"));
 
-    let result = rhoxy::protocol::https::handle_request(
-        &mut writer,
-        &mut reader,
-        "127.0.0.1:443".to_string(),
-    )
-    .await;
+    let result =
+        rhoxy::protocol::https::handle_request(&mut writer, &mut reader, "127.0.0.1:443".into())
+            .await;
 
     assert!(result.is_ok());
     let response = String::from_utf8_lossy(&writer);
     assert!(
         response.contains("403 Forbidden"),
         "Expected 403 for CONNECT to localhost, got: {}",
-        response
-    );
-}
-
-#[tokio::test]
-async fn test_connect_tunnel_unreachable_host() {
-    let mut writer = Vec::new();
-    let mut reader = tokio::io::BufReader::new(std::io::Cursor::new(
-        "Host: unreachable.test.invalid:1\r\n\r\n",
-    ));
-
-    let result = rhoxy::protocol::https::handle_request(
-        &mut writer,
-        &mut reader,
-        "unreachable.test.invalid:1".to_string(),
-    )
-    .await;
-
-    assert!(result.is_ok(), "Handler should not propagate error");
-    let response = String::from_utf8_lossy(&writer);
-    assert!(
-        response.contains("502 Bad Gateway") || response.contains("403 Forbidden"),
-        "Expected 502 or 403, got: {}",
         response
     );
 }

--- a/tests/proxy_server.rs
+++ b/tests/proxy_server.rs
@@ -1,0 +1,94 @@
+//! Integration tests for production server behaviors: connection timeout
+//! and connection limiting.
+//!
+//! These tests do NOT require the `_test-support` feature because they do not
+//! forward to localhost upstreams — they test proxy server infrastructure only.
+//!
+//!     cargo test --test proxy_server
+
+mod common;
+
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+// ---------------------------------------------------------------------------
+// Connection timeout
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_connection_timeout_closes_idle_connection() {
+    let proxy = common::start_proxy_with_timeout(Duration::from_secs(1)).await;
+
+    let mut stream = TcpStream::connect(proxy).await.unwrap();
+
+    // Send an incomplete request line — never send \r\n to complete it.
+    // The proxy blocks on read_line_bounded waiting for the rest.
+    stream.write_all(b"GET ").await.unwrap();
+
+    // Wait longer than the timeout
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    // The proxy should have timed out and closed the connection.
+    let mut buf = vec![0u8; 1024];
+    let n = stream.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0, "Expected EOF after timeout, but got {} bytes", n);
+}
+
+// ---------------------------------------------------------------------------
+// Connection limit — rejection
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_connection_limit_rejects_excess() {
+    let proxy = common::start_proxy_with_limit(2).await;
+
+    // Hold two connections by connecting without sending.
+    // The proxy blocks on read_line_bounded, keeping permits held.
+    let _conn1 = TcpStream::connect(proxy).await.unwrap();
+    let _conn2 = TcpStream::connect(proxy).await.unwrap();
+
+    // Give the accept loop time to process both connections
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Third connection: accepted at TCP level but immediately closed by proxy.
+    let mut conn3 = TcpStream::connect(proxy).await.unwrap();
+    let mut buf = vec![0u8; 1024];
+    let result = tokio::time::timeout(Duration::from_secs(2), conn3.read(&mut buf)).await;
+
+    match result {
+        Ok(Ok(0)) => {}  // EOF — connection rejected, as expected
+        Ok(Err(_)) => {} // Connection reset — also acceptable
+        other => panic!(
+            "Expected connection rejection (EOF or reset), got: {:?}",
+            other
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Connection limit — recovery
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_connection_limit_recovers_after_completion() {
+    let proxy = common::start_proxy_with_limit(1).await;
+
+    // First request: health check completes and releases the permit.
+    let response1 =
+        common::send_raw(proxy, b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
+    assert!(
+        response1.contains("200 OK"),
+        "First health check should succeed, got: {}",
+        response1
+    );
+
+    // Second request: should succeed because the permit was released.
+    let response2 =
+        common::send_raw(proxy, b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n").await;
+    assert!(
+        response2.contains("200 OK"),
+        "Second health check should succeed after permit release, got: {}",
+        response2
+    );
+}


### PR DESCRIPTION
## Summary

- Add comprehensive integration tests covering the full proxy TCP lifecycle
- Split into `proxy_integration.rs` (SSRF protection, health check) and `proxy_forwarding.rs` (HTTP/HTTPS forwarding, requires `_test-support` feature)
- Add `proxy_server.rs` for production server behaviors (timeout, connection limiting)
- Add `_test-support` cargo feature with SSRF bypass mechanism so forwarding tests can use localhost upstreams
- Extract `handle_connection` to `lib.rs` as a single source of truth — `main.rs` and all test helpers call the same code path
- Extract shared `read_upstream_body` helper for DRY test upstream servers
- Rewrite `malformed_request.rs` to use shared test helpers

## Closes

Closes #36
Closes #37
Closes #38
Closes #39

## Test coverage added

| Test | What it covers |
|------|---------------|
| `test_ssrf_bypass_active` | Verifies SSRF bypass mechanism works |
| `test_ssrf_bypass_not_active_in_integration_tests` | Guards against accidental bypass leakage |
| `test_http_get_forwarding` | Full GET → upstream → response |
| `test_http_post_with_body` | POST with Content-Length body forwarding |
| `test_http_response_headers_forwarded` | Custom response headers passed through |
| `test_http_hop_by_hop_headers_stripped_and_others_forwarded` | Proxy-Authorization stripped, X-Keep forwarded |
| `test_health_check_returns_200` | Relative /health intercepted by proxy |
| `test_health_check_not_intercepted_for_absolute_url` | Absolute URL /health forwarded to upstream |
| `test_http_ssrf_block_private_address` | 403 for 127.0.0.1 |
| `test_connect_ssrf_block_private_address` | 403 for CONNECT to 127.0.0.1 |
| `test_http_ssrf_block_localhost` | 403 for localhost |
| `test_connect_handler_ssrf_blocks_private` | Handler-level SSRF block |
| `test_http_502_on_closed_port` | 502 for unreachable upstream (deterministic) |
| `test_connect_502_on_closed_port` | 502 for CONNECT to closed port |
| `test_connect_tunnel_bidirectional` | Full CONNECT tunnel with echo server |
| `test_proxy_handles_multiple_sequential_requests` | 3 sequential requests through one proxy |
| `test_proxy_handles_concurrent_requests` | 10 simultaneous requests via tokio::spawn |
| `test_http_post_large_body` | 128 KiB body forwarded correctly |
| `test_http_post_chunked_transfer_encoding` | Chunked body reassembly end-to-end |
| `test_connection_timeout_closes_idle_connection` | Partial request triggers EOF after timeout |
| `test_connection_limit_rejects_excess` | Excess connections get EOF |
| `test_connection_limit_recovers_after_completion` | Permits released after connection completes |

## Architecture

```
lib.rs::handle_connection()     ← single source of truth
    ├── main.rs                 ← thin wrapper (stream split + timeout + semaphore)
    ├── tests/common/mod.rs     ← test proxy calls handle_connection(None)
    │   ├── start_proxy / start_proxy_with_timeout / start_proxy_with_limit
    │   ├── start_upstream / start_looping_upstream
    │   ├── send_raw / read_upstream_body
    ├── tests/proxy_integration.rs  ← SSRF + health check (always runs)
    ├── tests/proxy_forwarding.rs   ← forwarding tests (behind _test-support)
    ├── tests/proxy_server.rs       ← timeout + connection limiting (always runs)
    └── tests/malformed_request.rs  ← uses shared helpers
```

## How to run

```bash
# Basic tests (always work)
cargo test

# Full suite including forwarding tests
cargo test --features _test-support
```

## Test plan

- [x] `cargo test --features _test-support` passes (92 tests)
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --features _test-support -- -D warnings` clean
- [x] Zero compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)